### PR TITLE
Migrate LangChain to LangGraph

### DIFF
--- a/frontend/src/Question.tsx
+++ b/frontend/src/Question.tsx
@@ -29,7 +29,7 @@ export const QuestionCard: FC<Props> = ({ questionsPromise }) => {
                                     <li key={`${e.question}-choice-${j}`}>
                                         <button onClick={async () => {
                                             await postAnswer(e.question, a)
-                                        }}>{e.question}</button>
+                                        }}>{a}</button>
                                     </li>
                                 )
                             })}

--- a/scraper/chatbot.py
+++ b/scraper/chatbot.py
@@ -6,7 +6,7 @@ def connect_ai():
 		# Create a new client and connect to the server
 		if 'llm' not in g:
 			llm = ChatOpenAI(
-				model="gpt-4o-mini",
+				model="gpt-4o",
 				temperature=0,
 				max_tokens=None,
 				timeout=5000,

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import json
-from flask import current_app
+from flask import current_app, g
 from langchain_openai import ChatOpenAI
 import requests
 from typing import List
@@ -8,7 +8,8 @@ from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 from langchain_core.tools import InjectedToolArg, tool
 from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
-from langgraph.prebuilt import ToolNode
+from langgraph.prebuilt import ToolNode, create_react_agent
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import StateGraph, MessagesState
 from typing_extensions import Annotated
 
@@ -22,89 +23,43 @@ class Questions(BaseModel):
   questions: List[Question] = Field(..., description="List of questions to figure out the user's intent.")
 
 @tool
-def all_of_tag(tag: str, soup: Annotated[BeautifulSoup, InjectedToolArg]):
+def all_of_tag(tag: str):#, soup: Annotated[BeautifulSoup, InjectedToolArg]):
   '''First, use this to retrieve information about the webpage.
 
   Args:
     tag: html tag we want to retrieve all occurences of
   '''
-  return { tag: list(map(lambda item: item.string.strip(), soup.find_all(tag))) }
+  return { tag: list(map(lambda item: item.string.strip(), g.soup.find_all(tag))) }
 
 @tool
-def get_tag(tag: str, soup: Annotated[BeautifulSoup, InjectedToolArg]):
+def get_tag(tag: str):#, soup: Annotated[BeautifulSoup, InjectedToolArg]):
   '''First, use this to retrieve information about the webpage.
 
   Args:
     tag: html tag we want to retrieve first occurrence of
   '''
-  return soup.find(tag)
-
-# def call_model(state: AgentState):
-#   messages = state["messages"]
-#   last_message = messages[-1]
-#   if len(last_message.tool_calls) == 1 and last_message.tool_calls[0]
-
-
-
+  return g.soup.find(tag)
 
 def req():
   from . import chatbot
   # r = requests.get('https://realpython.github.io/fake-jobs/')
   r = requests.get('https://www.apple.com/')
   llm = chatbot.connect_ai()
-  soup = BeautifulSoup(r.content, 'html.parser')
-
-  messages = [
-    SystemMessage(content="First, use the all_of_tag tool to gather information about a website until you can formulate questions to ask the user."),
-    SystemMessage(content="Finally, format them using the Questions tool"),
-    SystemMessage(content="Information about the contents of the website comes from all_of_tag."),
-  ]
+  g.soup = BeautifulSoup(r.content, 'html.parser') # TODO don't set this in global variable. Pass it in hidden from llm.
 
   tools = [all_of_tag, Questions]
 
-  llm_with_tools = llm.bind_tools(tools, tool_choice="any", strict=True)
-  llm_output = llm_with_tools.invoke(messages)
-  # print("llm_output 1 ", llm_output)
-  messages.append(llm_output)
-  tool_mapping = { "all_of_tag": all_of_tag, "Questions": Questions, "get_tag": get_tag }
+  config = {"configurable": {"thread_id": "test-thread"}}
+  memory = MemorySaver()
+  system_msg = "You ask questions to website visitors to help sort them based on intent. First, use the all_of_tag tool to gather information about the website. Finally, format them using the Questions tool."
 
-  print("All the tool_calls ", llm_output.tool_calls)
+  agent_executor = create_react_agent(llm, tools, state_modifier=system_msg, checkpointer=memory)
+  output = agent_executor.invoke({ "messages": [("user", "Visitor to apple.com")]}, config)
+  print("Full convo: ", output["messages"])
 
-  # tool_node = ToolNode(tools)
-  # workflow = StateGraph()
+  print("\nOutput: ", output["messages"][-1].content)
 
-  for tool_call in llm_output.tool_calls:
-    # if I intend to extend this logic, should use langgraph for llm logic instead
-    tool = tool_mapping[tool_call["name"]]
-    call = deepcopy(tool_call)
-    call["args"]["soup"] = soup
-    tool_output = tool.invoke(call["args"])
-    tool_msg = ToolMessage(content=json.dumps(tool_output), tool_call_id=tool_call["id"])
-    print("\nTool msg: ", tool_msg)
-    messages.append(tool_msg)
-    # print("\nmessages: ", messages)
-  messages.append("Format your response using the Questions tool")
-  print("Made it to here. ", len(tool_call))
-  print("Tool output ", tool_output)
-  questions = llm_with_tools.invoke(messages)
-
-  tool_call_final = questions.tool_calls
-  print("\nTool call final: ", tool_call_final)
-
-
-
-  q_index = -1 #tool_call_final.index(lambda e: True if e["name"] == 'Questions' else False)
-  final = {}
-  for call in questions.tool_calls:
-    if call["name"] == "Questions":
-      final = call
-      break
-  if (len(final.keys()) == 0):
-    raise Exception("No Questions in output. " + str(questions.tool_calls))
-  print("\nFinal: ", final)
-  print("\nfinal answer: ", final["args"]["questions"])
-
-  return final["args"]["questions"]
+  return output["messages"][-1].content
 
 def soup():
   r = requests.get('https://www.apple.com/')

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,16 +1,12 @@
-from copy import deepcopy
 import json
 from flask import current_app, g
-from langchain_openai import ChatOpenAI
 import requests
 from typing import List
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 from langchain_core.tools import InjectedToolArg, tool
-from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langgraph.prebuilt import ToolNode, create_react_agent
-from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import StateGraph, MessagesState
+from langgraph.graph import StateGraph, MessagesState, END
 from typing_extensions import Annotated
 
 class Question(BaseModel):
@@ -21,6 +17,11 @@ class Question(BaseModel):
 class Questions(BaseModel):
   '''Response to the user.'''
   questions: List[Question] = Field(..., description="List of questions to figure out the user's intent.")
+
+# Inherit 'messages' key from MessagesState, which is a list of chat messages
+class AgentState(MessagesState):
+  # Final structured response from the agent
+  final_response: Questions
 
 @tool
 def all_of_tag(tag: str):#, soup: Annotated[BeautifulSoup, InjectedToolArg]):
@@ -40,6 +41,28 @@ def get_tag(tag: str):#, soup: Annotated[BeautifulSoup, InjectedToolArg]):
   '''
   return g.soup.find(tag)
 
+
+# Define the function that responds to the user
+def respond(state: AgentState):
+  # Construct the final answer from the arguments of the last tool call
+  response = Questions(**state["messages"][-1].tool_calls[0]["args"])
+  # We return the final answer
+  return {"final_response": response}
+
+# Determine whether to continue or not
+def should_continue(state: AgentState):
+  messages = state["messages"]
+  last_message = messages[-1]
+  # If there is only one tool call and it is the response tool call we respond to the user
+  if (
+    len(last_message.tool_calls) == 1
+    and last_message.tool_calls[0]["name"] == "Questions"
+  ):
+    return "respond"
+  # Otherwise we will use the tool node again
+  else:
+    return "continue"
+
 def req():
   from . import chatbot
   # r = requests.get('https://realpython.github.io/fake-jobs/')
@@ -49,17 +72,27 @@ def req():
 
   tools = [all_of_tag, Questions]
 
-  config = {"configurable": {"thread_id": "test-thread"}}
-  memory = MemorySaver()
-  system_msg = "You ask questions to website visitors to help sort them based on intent. First, use the all_of_tag tool to gather information about the website. Finally, format them using the Questions tool."
+  def call_model(state: AgentState):
+    response = model_with_tools.invoke(state["messages"])
+    # We return a list, because this will get added to the existing list
+    return {"messages": [response]}
 
-  agent_executor = create_react_agent(llm, tools, state_modifier=system_msg, checkpointer=memory)
-  output = agent_executor.invoke({ "messages": [("user", "Visitor to apple.com")]}, config)
-  print("Full convo: ", output["messages"])
+  model_with_tools = llm.bind_tools(tools, tool_choice="any")
 
-  print("\nOutput: ", output["messages"][-1].content)
+  workflow = StateGraph(AgentState)
+  workflow.add_node("agent", call_model)
+  workflow.add_node("respond", respond)
+  workflow.add_node("tools", ToolNode(tools))
 
-  return output["messages"][-1].content
+  workflow.set_entry_point("agent")
+  workflow.add_conditional_edges("agent", should_continue, {"continue": "tools", "respond": "respond"})
+  workflow.add_edge("tools", "agent")
+  workflow.add_edge("respond", END)
+  graph = workflow.compile()
+
+  output = graph.invoke(input={"messages": [("user", "Visitor to apple.com")]})["final_response"]
+  print("Output: ", output)
+  return output.model_dump(mode='json')
 
 def soup():
   r = requests.get('https://www.apple.com/')


### PR DESCRIPTION
Migrate LLM from legacy tool-calling to langgraph

Contains a temporary workaround for passing runtime values to tools, hidden from the LLM, by storing the scraped data object `soup` in `g.soup`. This should be changed in a future update.

Also fixes display issue on frontend where answer buttons were displaying the question text.